### PR TITLE
Add environment variable for S3 whether to use http or https

### DIFF
--- a/init.go
+++ b/init.go
@@ -29,6 +29,7 @@ func init() {
 	s3Endpoint := os.Getenv("PN_SMM_CONFIG_S3_ENDPOINT")
 	s3AccessKey := os.Getenv("PN_SMM_CONFIG_S3_ACCESS_KEY")
 	s3AccessSecret := os.Getenv("PN_SMM_CONFIG_S3_ACCESS_SECRET")
+	s3SecureEnv := os.Getenv("PN_SMM_CONFIG_S3_SECURE")
 
 	postgresURI := os.Getenv("PN_SMM_POSTGRES_URI")
 	kerberosPassword := os.Getenv("PN_SMM_KERBEROS_PASSWORD")
@@ -116,9 +117,15 @@ func init() {
 
 	staticCredentials := credentials.NewStaticV4(s3AccessKey, s3AccessSecret, "")
 
+	s3Secure, err := strconv.ParseBool(s3SecureEnv)
+	if err != nil {
+		globals.Logger.Warningf("PN_SMM_CONFIG_S3_SECURE environment variable not set. Using default value: %t", true)
+		s3Secure = true
+	}
+
 	minIOClient, err := minio.New(s3Endpoint, &minio.Options{
 		Creds:  staticCredentials,
-		Secure: true,
+		Secure: s3Secure,
 	})
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

Resolves N/A

### Changes:
- Added an environment variable `PN_SMM_CONFIG_S3_SECURE` to tell the Minio client whether to connect with HTTP or HTTPS
<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [x] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.